### PR TITLE
Fix to update CA certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,8 @@ LABEL "repository"="https://github.com/lowply/build-hugo"
 LABEL "homepage"="https://github.com/lowply"
 LABEL "maintainer"="Sho Mizutani <lowply@github.com>"
 
+RUN apt-get update -y && apt-get install ca-certificates -y
+RUN update-ca-certificates
+
 ADD https://github.com/gohugoio/hugo/releases/download/v0.54.0/hugo_extended_0.54.0_Linux-64bit.deb /usr/local/src
 RUN dpkg -i /usr/local/src/hugo_extended_0.54.0_Linux-64bit.deb


### PR DESCRIPTION
When I build hugo site whose content includes twitter shortcode (e.g.: `{{< tweet 1105403306413682688 >}}`), the error below occurs:
```
Building sites … ERROR 2019/03/12 13:46:28 Failed to get JSON resource "https://api.twitter.com/1/statuses/oembed.json?id=1105403306413682688&dnt=false": Get https://api.twitter.com/1/statuses/oembed.json?id=1105403306413682688&dnt=false: x509: certificate signed by unknown authority
```

This error occurs because CA certificates are old.