### PR TITLE
Change ENTRYPOINT from shell to exec form

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ RUN apt-get update -y && apt-get install ca-certificates -y
 RUN update-ca-certificates
 ADD https://github.com/gohugoio/hugo/releases/download/v0.73.0/hugo_extended_0.73.0_Linux-64bit.deb /tmp
 RUN dpkg -i /tmp/hugo_extended_0.73.0_Linux-64bit.deb
-ENTRYPOINT hugo
+ENTRYPOINT ["hugo"]


### PR DESCRIPTION
Hi @lowply,

### Problem this PR fixes
Arguments get passed through to docker but hugo inside the container doesn't see them.

### Expected Behaviour
Passing `args` to the action will make the docker entry point pick up these arguments
```yaml
    - name: Build Hugo
      uses: lowply/build-hugo@v0.73.0
      with:
        args: "--config hugo-config.toml"
```

### Solution
Changing the [ENTRYPOINT](https://github.com/lowply/build-hugo/blob/master/Dockerfile#L6) from `shell` form to `exec` form. This allows arguments to be passed to the entry point. https://docs.docker.com/engine/reference/builder/#entrypoint