### PR TITLE
Use cli/cli as actions/create-release has been discontinued

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,14 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@master
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@latest
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ github.ref }}
-        draft: false
-        prerelease: false
+      uses: actions/checkout@v2
+    - name: Run gh release create
+      run: |
+        echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
+        gh release create ${GITHUB_REF/refs\/tags\//} -t ${GITHUB_REF/refs\/tags\//}

--- a/script/release.sh
+++ b/script/release.sh
@@ -2,5 +2,5 @@
 
 git checkout master
 git pull
-git tag "v$(cat VERSION)"
+git tag -a "v$(cat VERSION)" -m "Update to v$(cat VERSION)"
 git push origin --tags


### PR DESCRIPTION
Switching to [cli/cli](https://github.com/cli/cli) to create releases as [actions/create-release](https://github.com/actions/create-release) has been discontinued.