### PR TITLE
use debian bullseye-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 RUN apt-get update -y && apt-get install ca-certificates -y
 RUN update-ca-certificates
 ADD https://github.com/gohugoio/hugo/releases/download/v0.148.1/hugo_extended_0.148.1_linux-amd64.deb /tmp


### PR DESCRIPTION
Debian buster has reached end of life. This PR upgrades the action to use bullseye-slim. Looks like it works when I tested it here: https://github.com/Arizard/less-coffee-hugo/actions/runs/16266513889/job/45923339434
<img width="1323" height="669" alt="Screenshot 2025-07-14 at 10 15 48 pm" src="https://github.com/user-attachments/assets/773f253f-8a92-46db-afd3-12c48bc9edf7" />
